### PR TITLE
Upgrade PostgreSQL JDBC driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ include {
 	from('modules/shared/postgis.gradle') {
 		postgis(
 			'2.0.1', // PostGIS driver version
-			'9.2-1002-jdbc4', // PostgreSQL driver version
+			'9.4-1206-jdbc4', // PostgreSQL driver version
 			[
 				// buddies
 				'eu.esdihumboldt.hale.io.jdbc',


### PR DESCRIPTION
MATERIALIZED VIEWS were introduced with PostgreSQL 9.3 and the
9.2 JDBC driver used before does not support them.