### PR TITLE
Prevent reimport of javax.annotation.* packages in annotations fragment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -451,7 +451,7 @@ platform {
 			bundleName = 'javax.annotation Extensions'
 			version = '1.2' // version should be equal to javax.annotation-api module version
 			instruction 'Fragment-Host', 'system.bundle;extension:=framework'
-			instruction 'Export-Package', "javax.annotation.*;version=$version"
+			instruction 'Export-Package', "javax.annotation.*;version=$version;-noimport:=true"
 			instruction 'Import-Package', '*'
 		}
 	}


### PR DESCRIPTION
It appears that since hale-plaform uses bnd-platform:1.6.0-SNAPSHOT the `MANIFEST.MF` generated for the merged `javax.annotation.extensions` bundle now contains `Import-Package` lines for the exported `javax.annotation` package. This causes a hale studio compile error in clean enviornment, i.e. when there is no previously cached version of the `javax.annotation.extensions` bundle available.

This patch prevents the addition of the problematic `Import-Package` statements.