### PR TITLE
Remove problematic Require-Capability line

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -491,6 +491,10 @@ platform {
 		instruction 'Export-Package', "ru.yandex.qatools.allure.aspects;version=$version;aspects=\"AllureAttachAspects,AllureStepsAspects,AllureParametersAspects\",*;version=$version"
 	}
 	bundle 'org.aspectj:aspectjweaver:1.8.3'
+
+        bnd group: 'net.sf.ezmorph', name: 'ezmorph', {
+                instruction '-removeheaders', 'Require-Capability'
+        }
 	
 }
 


### PR DESCRIPTION
The removed filter `((osgi.ee=JavaSE)(version=1.1))` causes validation errors in the HALE product after the platform upgrade to Photon (see halestudio/hale#659).

Do not merge yet, waiting for `shared-platform` merge to update submodule.