### PR TITLE
build: upgrade to Eclipse Photon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ repositories {
 }
 
 // platform version
-version = '3.4.0'
+version = '3.5.0'
 
 ext {
 	geotoolsVersion = '12.2'

--- a/modules/jetty-support/jetty-support.gradle
+++ b/modules/jetty-support/jetty-support.gradle
@@ -1,6 +1,7 @@
 // Adapted jetty related bundles
 platform {
 	def jettyVersion = '9.2.1.v20140609'
+	//def jettyVersion = '9.4.10.v20180503' // Originally upgraded during the platform migration to Photon. Not sure why anymore, so left out for the moment
 	def jettyGroup = 'org.eclipse.jetty'
 	
 	feature id: 'eu.esdihumboldt.hale.platform.jetty',


### PR DESCRIPTION
This commit was part of the platform migration to Eclipse Photon mid-2018 but never made it to the main repo.

https://github.com/halestudio/hale/issues/631