### PR TITLE
build: add Eclipse 2020-03 and GEF legacy repositories to p2 mirrors

### DIFF
--- a/p2.json
+++ b/p2.json
@@ -4,5 +4,8 @@
 	"jetty-8": "http://download.eclipse.org/jetty/updates/jetty-bundles-8.x/8.1.18.v20150929",
 	"photon-eclipse": "http://download.eclipse.org/eclipse/updates/4.8",
 	"photon-releases": "http://download.eclipse.org/releases/photon",
-	"xtext-releases": "http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases"
+	"2020-03-eclipse": "http://download.eclipse.org/eclipse/updates/4.15",
+	"2020-03-releases": "http://download.eclipse.org/releases/2020-03",
+	"xtext-releases": "http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases",
+	"gef-legacy-releases": "http://download.eclipse.org/tools/gef/updates/legacy/releases"
 }


### PR DESCRIPTION
Corresponding mirrors were also created.

https://github.com/halestudio/hale/issues/822